### PR TITLE
Improve pre-install step

### DIFF
--- a/vmbackup.plg
+++ b/vmbackup.plg
@@ -163,14 +163,15 @@
     rm -f /tmp/&name;/*.json 2>/dev/null
 
     # remove old package files.
-    rm -f /boot/config/plugins/&name;/*.txz 2>/dev/null
-    rm -f /boot/config/plugins/&name;/packages/*.txz 2>/dev/null
-
-    # remove xmlstarlet.
-    removepkg xmlstarlet* 2>/dev/null
-
-    # remove pigz.
-    removepkg pigz* 2>/dev/null
+    find /boot/config/plugins/&name; -type f \
+      -maxdepth 2 -iname "*.txz" \
+      ! -iname "&xmlstarlet;.txz" \
+      ! -iname "&name;-&tag;-&version;.txz" \
+      -delete 2>/dev/null
+    
+    # remove legacy default cronjob.
+    ( crontab -l | grep -v -F "# Job for VM Backup plugin:" ) | crontab -
+    ( crontab -l | grep -v -F "/usr/local/emhttp/plugins/vmbackup/runscript.php run_backup > /dev/null" ) | crontab -
 
     # create plugin tmp folder.
     mkdir -p /tmp/&name;
@@ -212,9 +213,6 @@
 -->
 <FILE Run="/bin/bash">
   <INLINE>
-    # remove legacy default cronjob.
-    ( crontab -l | grep -v -F "# Job for VM Backup plugin:" ) | crontab -
-    ( crontab -l | grep -v -F "/usr/local/emhttp/plugins/vmbackup/runscript.php run_backup > /dev/null" ) | crontab -
     # update files and re-add missing cronjobs.
     /usr/local/emhttp/plugins/vmbackup/scripts/commands.sh update_user_conf_file all
     /usr/local/emhttp/plugins/vmbackup/scripts/commands.sh update_user_script all

--- a/vmbackup.plg
+++ b/vmbackup.plg
@@ -191,7 +191,7 @@
 <!--
   plugin package file.
 -->
-<FILE Name="/boot/config/plugins/&name;/&name;-&tag;-&version;.txz" Run="upgradepkg --install-new">
+<FILE Name="&packages;/&name;-&tag;-&version;.txz" Run="upgradepkg --install-new">
   <URL>&gitURL;/&name;-&tag;-&version;.txz</URL>
   <MD5>&MD5;</MD5>
 </FILE>


### PR DESCRIPTION
Hey JTok,

could you please merge this PR in case my router is running as a VM on UnRaid which will always move the plugin to:
`/boot/config/plugins-error/vmbackup.plg`. As there is no internet connection on boot and the script cannot fetch the plugin from github. If package exists in destination and the hash is correctly it will not being downloaded.
But before the script get to the point where the package install process is started it will be deleted and needs to be downloaded every time it get installed - even on reboot.

You don't really need to do a version bump because nobody else seems to care about that. But if you want to feel free.

#### This will actually do:
- find any file with ending `.txz` in path + one subfolder of `/boot/config/plugins/vmbackup` but not the actual ones.
- moved cron-job deletion to pre-install (just by design -cleanup processes in this section)
- respect installed packages (i.e. pigz) as they may in use by other plugins.
  => the package `xmlstarlet` will get overridden if the version if this plugin is newer than installed one which I think shouldn't be a big deal. Check install command `upgradepkg --install-new`.

<br/>

best regards

realizelol